### PR TITLE
Change executables to the common code style

### DIFF
--- a/switch-window.sh
+++ b/switch-window.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 # Get IDs for all the open windows
 # ids=$($HOME/.scripts/get-window-id.sh a)
 ids=$(xprop -root |grep _NET_CLIENT_LIST_STACKING\(WINDOW\) |cut -d"#" -f2| tr -d " "|tr "," " ")


### PR DESCRIPTION
As I know

> Executables must start with `#!/bin/bash` and a minimum number of flags. Use `set` to set shell options so that calling your script as `bash script_name` does not break its functionality.

For sample [Shell Style Guide](https://google.github.io/styleguide/shellguide.html#s1.1-which-shell-to-use).

It's not necessary but It is more compatible than `#!/usr/bin/bash`.